### PR TITLE
Fix #31

### DIFF
--- a/Source/Runtime/Core/Private/CoreGlobals.cpp
+++ b/Source/Runtime/Core/Private/CoreGlobals.cpp
@@ -1,0 +1,4 @@
+#include "CoreGlobals.h"
+
+DEFINE_LOG_CATEGORY(CoreLog);
+DEFINE_LOG_CATEGORY(LogTemp);

--- a/Source/Runtime/Core/Private/CoreModule.cpp
+++ b/Source/Runtime/Core/Private/CoreModule.cpp
@@ -1,3 +1,0 @@
-#include "CoreModule.h"
-
-DEFINE_LOG_CATEGORY(CoreLog);

--- a/Source/Runtime/Core/Private/Windows/WindowsPlatformFile.cpp
+++ b/Source/Runtime/Core/Private/Windows/WindowsPlatformFile.cpp
@@ -1,6 +1,6 @@
 ﻿#include "Windows/WindowsPlatformFile.h"
 #include "Logging/LoggingMacros.h"
-#include "CoreModule.h"
+#include "CoreGlobals.h"
 
 #pragma region API
 WindowsPlatformFile::~WindowsPlatformFile()

--- a/Source/Runtime/Core/Public/CoreGlobals.h
+++ b/Source/Runtime/Core/Public/CoreGlobals.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Core_API.h"
+#include "MacrosHelper.h"
+#include "Logging/LoggingMacros.h"
+
+// Log category for core logging
+CORE_API DECLARE_LOG_CATEGORY(CoreLog);
+// Log category for temp logging - Use for debug only
+CORE_API DECLARE_LOG_CATEGORY(LogTemp);

--- a/Source/Runtime/Core/Public/CoreMinimals.h
+++ b/Source/Runtime/Core/Public/CoreMinimals.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/* DEFINES *******************************************************************/
+#include "MacrosHelper.h"
+#include "Logging/LoggingMacros.h"
+#include "Profiling/ProfilingMacros.h"
+
+#include "CoreGlobals.h"
+
+#include "Version.h"

--- a/Source/Runtime/Core/Public/CoreModule.h
+++ b/Source/Runtime/Core/Public/CoreModule.h
@@ -1,6 +1,0 @@
-#pragma once
-
-#include "MacrosHelper.h"
-#include "Logging/LoggingMacros.h"
-
-DECLARE_LOG_CATEGORY(CoreLog);

--- a/Source/Runtime/Core/Public/EngineStaticData.h
+++ b/Source/Runtime/Core/Public/EngineStaticData.h
@@ -1,8 +1,10 @@
 ﻿#pragma once
 
+#include "Core_API.h"
+
 #include <string>
 
-struct EngineStaticData
+struct CORE_API EngineStaticData
 {
 	std::string EngineRootDirectory;
 };

--- a/Source/Runtime/Core/Public/MacrosHelper.h
+++ b/Source/Runtime/Core/Public/MacrosHelper.h
@@ -38,7 +38,7 @@
 
 /**
  * Platform header will change the include path depending of the current platform.
- * 
+ *
  * "Windows = Windows/Windows[HeaderName]"
  * "Linux = Linux/Linux[HeaderName]"
  */

--- a/Source/Runtime/Core/Public/Module.h
+++ b/Source/Runtime/Core/Public/Module.h
@@ -2,6 +2,7 @@
 
 #include "Core_API.h"
 #include "MacrosHelper.h"
+
 #include <unordered_map>
 #include <vector>
 
@@ -43,7 +44,7 @@ public:
 	virtual void ShutdownModule() = 0;
 };
 
-/** 
+/**
  * The module manager is here to handle all the module.
  */
 class CORE_API ModuleManager

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformFile.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformFile.h
@@ -10,7 +10,7 @@
 
 /**
  * A class that provides file I/O functionality for the current platform.
- * 
+ *
  * WINDOW ONLY!
  */
 class CORE_API WindowsPlatformFile
@@ -52,7 +52,7 @@ public:
 public:
 	/**
 	 * Copy the platform file to the path destination.
-	 * 
+	 *
 	 * \param src The source file to copy
 	 * \param path The destination path to copy the file to. (without the file name and extension)
 	 */
@@ -60,7 +60,7 @@ public:
 	/**
 	 * Open file or create it if doesn't exist.
 	 * \note All the parent directories are created automatically.
-	 * 
+	 *
 	 * \param fullPath The full path to the file to create. (including the file name and extension)
 	 * \return the handle of the new file.
 	 */
@@ -68,7 +68,7 @@ public:
 	/**
 	 * Create a directory at the specified path. (including all the parent directories)
 	 * \note that when creating a file the parent directory are created automatically.
-	 * 
+	 *
 	 * \param path The path to the directory to create.
 	 * \return true if the directory was created, false otherwise.
 	 */


### PR DESCRIPTION
CoreModule.h refacto

I created a coreGlobals header file for all the globals variable of the core module
I created a coreMinimals file for all the basic feature that will be often included (provided by the core module)
I fix some whitespaces & exported the EngineStaticData struct