### PR TITLE
#43 Fixed

### DIFF
--- a/Source/Programs/CrashHandler/premake5.lua
+++ b/Source/Programs/CrashHandler/premake5.lua
@@ -1,11 +1,9 @@
+include "../../../vendor/Premake5/Utils.lua"
 
 project "CrashHandler"
 	kind "ConsoleApp"
-	language "C++"
-	location (projectFileLocation)
 
-	targetdir (buildOutput .. "/%{prj.name}")
-	objdir (intermediateOutput .. "/%{prj.name}")
+	UseProjectDefaultConfig()
 
 	files
 	{

--- a/Source/Runtime/Core/premake5.lua
+++ b/Source/Runtime/Core/premake5.lua
@@ -1,15 +1,7 @@
-﻿
-include "../../../vendor/Premake5/GlobalVariable.lua"
+﻿include "../../../vendor/Premake5/Utils.lua"
 
 project "Core"
-	kind "SharedLib"
-	language "C++"
-	cppdialect "C++20"
-
-	targetdir (buildOutput .. "/OpenVoxel")
-	objdir (intermediateOutput .. "/OpenVoxel")
-
-	location (projectFileLocation)
+	UseModuleDefaultConfig()
 
 	files
 	{
@@ -33,33 +25,4 @@ project "Core"
 		"GLFW",
 	}
 
-	staticruntime "off"
-	systemversion "latest"
-
-	filter "configurations:*Debug"
-		runtime "Debug"
-		symbols "on"
-	filter "configurations:*Release"
-		runtime "Release"
-		optimize "on"
-		symbols "off"
-	filter {}
-
-	-- /* DEFINES ************************************************************/
-
 	defines "OV_BUILD_CORE_DLL"
-
-	-- Config specific
-	filter "configurations:Editor*"
-		defines "WITH_EDITOR"
-	filter "configurations:*Debug"
-		defines "OV_DEBUG"
-
-	-- System specific
-	filter "system:windows"
-		defines "PLATFORM_WINDOWS"
-	filter "system:linux"
-		defines "PLATFORM_LINUX"
-	filter "system:macosx"
-		defines "PLATFORM_MAC"
-	filter {}

--- a/Source/Runtime/Engine/premake5.lua
+++ b/Source/Runtime/Engine/premake5.lua
@@ -1,15 +1,7 @@
-﻿
-include "../../../vendor/Premake5/GlobalVariable.lua"
+﻿include "../../../vendor/Premake5/Utils.lua"
 
 project "Engine"
-	kind "SharedLib"
-	language "C++"
-	cppdialect "C++20"
-
-	targetdir (buildOutput .. "/OpenVoxel")
-	objdir (intermediateOutput .. "/OpenVoxel")
-
-	location (projectFileLocation)
+	UseModuleDefaultConfig()
 
 	files
 	{
@@ -43,33 +35,4 @@ project "Engine"
 		"Renderer",
 	}
 
-	staticruntime "off"
-	systemversion "latest"
-
-	filter "configurations:*Debug"
-		runtime "Debug"
-		symbols "on"
-	filter "configurations:*Release"
-		runtime "Release"
-		optimize "on"
-		symbols "off"
-	filter {}
-
-	-- /* DEFINES ************************************************************/
-
 	defines "OV_BUILD_ENGINE_DLL"
-
-	-- Config specific
-	filter "configurations:Editor*"
-		defines "WITH_EDITOR"
-	filter "configurations:*Debug"
-		defines "OV_DEBUG"
-
-	-- System specific
-	filter "system:windows"
-		defines "PLATFORM_WINDOWS"
-	filter "system:linux"
-		defines "PLATFORM_LINUX"
-	filter "system:macosx"
-		defines "PLATFORM_MAC"
-	filter {}

--- a/Source/Runtime/Renderer/premake5.lua
+++ b/Source/Runtime/Renderer/premake5.lua
@@ -1,15 +1,7 @@
-﻿
-include "../../../vendor/Premake5/GlobalVariable.lua"
+﻿include "../../../vendor/Premake5/Utils.lua"
 
 project "Renderer"
-	kind "SharedLib"
-	language "C++"
-	cppdialect "C++20"
-
-	targetdir (buildOutput .. "/OpenVoxel")
-	objdir (intermediateOutput .. "/OpenVoxel")
-
-	location (projectFileLocation)
+	UseModuleDefaultConfig()
 
 	files
 	{
@@ -41,34 +33,4 @@ project "Renderer"
 		"Core",
 	}
 
-	staticruntime "off"
-	systemversion "latest"
-
-	filter "configurations:*Debug"
-		runtime "Debug"
-		symbols "on"
-	filter "configurations:*Release"
-		runtime "Release"
-		optimize "on"
-		symbols "off"
-	filter {}
-
-	-- /* DEFINES ************************************************************/
-
 	defines "OV_BUILD_RENDERER_DLL"
-
-	-- Config specific
-	filter "configurations:Editor*"
-		defines "WITH_EDITOR"
-	filter "configurations:*Debug"
-		defines "OV_DEBUG"
-
-	-- System specific
-	filter "system:windows"
-		defines "PLATFORM_WINDOWS"
-	filter "system:linux"
-		defines "PLATFORM_LINUX"
-	filter "system:macosx"
-		defines "PLATFORM_MAC"
-	filter {}
-

--- a/Source/premake5.lua
+++ b/Source/premake5.lua
@@ -1,30 +1,17 @@
+include "../vendor/Premake5/Utils.lua"
+
 OV_RuntimeModules = { "Core", "Engine", "Renderer" }
 OV_EditorModules = { "Editor" }
 
 project "OpenVoxel"
 	kind "ConsoleApp"
-	language "C++"
-	location (projectFileLocation)
 
-	targetdir (buildOutput .. "/%{prj.name}")
-	objdir (intermediateOutput .. "/%{prj.name}")
+	UseProjectDefaultConfig()
 
-	-- TODO: Handle other OS (currently windows only)
-	cppdialect "C++20"
 	staticruntime "off"
 	systemversion "latest"
 
-	filter "configurations:*Debug"
-		runtime "Debug"
-		symbols "on"
-
-	filter "configurations:*Release"
-		runtime "Release"
-		optimize "on"
-		symbols "off"
-	filter {}
-
-	-- /* RUNTIME ************************************************************/
+	-- /* RUNTIME & EDITOR ****************************************************/
 
 	files
 	{
@@ -58,6 +45,10 @@ project "OpenVoxel"
 		table.translate(OV_RuntimeModules, function (moduleName) return (moduleName) end),
 	}
 
+	postbuildcommands {
+		table.translate(OV_RuntimeModules, function (moduleName) return ('{COPY} "' .. ModuleTargetOutput .. '/' .. moduleName .. '.dll" "%{cfg.targetdir}"') end),
+	}
+
 	-- /* EDITOR *************************************************************/
 
 	filter "configurations:Editor*"
@@ -72,21 +63,8 @@ project "OpenVoxel"
 			-- Modules
 			table.translate(OV_EditorModules, function (moduleName) return ("Editor/" .. moduleName .. "/Public") end),
 		}
-	filter {}
 
-	-- /* DEFINES ************************************************************/
-
-	-- Config specific
-	filter "configurations:Editor*"
-		defines "WITH_EDITOR"
-	filter "configurations:*Debug"
-		defines "OV_DEBUG"
-
-	-- System specific
-	filter "system:windows"
-		defines "PLATFORM_WINDOWS"
-	filter "system:linux"
-		defines "PLATFORM_LINUX"
-	filter "system:macosx"
-		defines "PLATFORM_MAC"
+		postbuildcommands {
+			table.translate(OV_EditorModules, function (moduleName) return ('{COPY} "' .. ModuleTargetOutput .. '/' .. moduleName .. '.dll" "%{cfg.targetdir}"') end),
+		}
 	filter {}

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,5 +1,5 @@
 include "./vendor/Premake5/GlobalVariable.lua"
-include "./vendor/Premake5/Extended/workspace_files.lua"
+include "./vendor/Premake5/Extended/workspace_files.lua" -- Allow files to be added to the workspace
 
 workspace "OpenVoxel"
 	architecture "x64"

--- a/vendor/Premake5/GlobalVariable.lua
+++ b/vendor/Premake5/GlobalVariable.lua
@@ -1,19 +1,20 @@
 ﻿VULKAN_SDK = os.getenv("VULKAN_SDK")
 
-outputdir = "%{cfg.buildcfg}-%{cfg.system}-%{cfg.architecture}"
+OutputDir = "%{cfg.buildcfg}-%{cfg.system}-%{cfg.architecture}"
 
-rootDir = os.getcwd()
+RootDir = os.getcwd()
 
--- if rootDir end with "vendor/Premake5", remove it
+-- if RootDir end with "vendor/Premake5", remove it
 -- this mean that the solution is generated with the build action
-if string.find(rootDir, "vendor/Premake5") then
-	rootDir = string.gsub(rootDir, "vendor/Premake5", "")
+if string.find(RootDir, "/vendor/Premake5") then
+	RootDir = string.gsub(RootDir, "/vendor/Premake5", "")
 end
 
-buildDir = rootDir .. "/build"
-intermediateDir = rootDir .. "/intermediate"
+BuildDir = RootDir .. "/build"
+IntermediateDir = RootDir .. "/intermediate"
 
-buildOutput = buildDir .. "/" .. outputdir
-intermediateOutput = intermediateDir .. "/" .. outputdir
+BuildOutput = BuildDir .. "/" .. OutputDir
+IntermediateOutput = IntermediateDir .. "/" .. OutputDir
 
-projectFileLocation = rootDir .. "/intermediate/ProjectFile"
+ProjectFileLocationOutput = RootDir .. "/intermediate/ProjectFile"
+

--- a/vendor/Premake5/Module.lua
+++ b/vendor/Premake5/Module.lua
@@ -1,0 +1,33 @@
+﻿include "GlobalVariable.lua"
+include "Shared.lua"
+
+ModuleTargetOutput = BuildOutput .. "/Modules"
+ModuleObjectOutput = IntermediateOutput .. "/Modules"
+
+function UseModuleDefaultConfig()
+	UseDefines()
+
+	kind "SharedLib" -- Dll
+
+	language "C++"
+	cppdialect "C++20"
+
+	location(ProjectFileLocationOutput) -- Where does the config file for the project will be generated
+	objdir(ModuleObjectOutput) -- Where the project object files will be generated
+	targetdir(ModuleTargetOutput) -- Where the project will be generated
+
+	-- Config specific
+	filter "configurations:*Debug"
+		runtime "Debug"
+		symbols "on"
+
+	filter "configurations:*Release"
+		runtime "Release"
+		optimize "on"
+		symbols "off"
+	filter {}
+
+	-- Compile with /MDd
+	staticruntime "off"
+	systemversion "latest"
+end

--- a/vendor/Premake5/Project.lua
+++ b/vendor/Premake5/Project.lua
@@ -1,0 +1,28 @@
+﻿include "GlobalVariable.lua"
+include "Shared.lua"
+
+ProjectTargetOutput = BuildOutput .. "/%{prj.name}"
+ProjectObjectOutput = IntermediateOutput .. "/%{prj.name}"
+
+function UseProjectDefaultConfig()
+	UseDefines()
+
+	language "C++"
+	cppdialect "C++20"
+
+	location(ProjectFileLocationOutput) -- Where does the config file for the project will be generated
+	objdir(ProjectObjectOutput) -- Where the project object files will be generated
+	targetdir(ProjectTargetOutput) -- Where the project will be generated
+
+	-- Config specific
+	filter "configurations:*Debug"
+		runtime "Debug"
+		symbols "on"
+
+	filter "configurations:*Release"
+		runtime "Release"
+		optimize "on"
+		symbols "off"
+	filter {}
+end
+

--- a/vendor/Premake5/Shared.lua
+++ b/vendor/Premake5/Shared.lua
@@ -1,0 +1,21 @@
+﻿include "GlobalVariable.lua"
+
+function UseDefines()
+
+	-- Config specific
+	filter "configurations:*Debug"
+		defines "OV_DEBUG"
+	filter "configurations:Editor*"
+		defines "WITH_EDITOR"
+
+	-- System specific
+	filter "system:windows"
+		defines "PLATFORM_WINDOWS"
+
+	filter "system:linux"
+		defines "PLATFORM_LINUX"
+
+	filter "system:macosx"
+		defines "PLATFORM_MAC"
+	filter {}
+end

--- a/vendor/Premake5/Utils.lua
+++ b/vendor/Premake5/Utils.lua
@@ -1,0 +1,3 @@
+﻿include "GlobalVariable.lua"
+include "Project.lua"
+include "Module.lua"

--- a/vendor/Premake5/premake5.lua
+++ b/vendor/Premake5/premake5.lua
@@ -7,14 +7,14 @@ project "Premake"
 
 	files
 	{
-		rootDir .. "vendor/Premake5/**.lua",
-		rootDir .. "**premake5.lua"
+		RootDir .. "/vendor/Premake5/**.lua",
+		RootDir .. "/**premake5.lua"
 	}
 
 	postbuildmessage ("Generating solution...")
 	postbuildcommands
 	{
 		-- @TODO: investigate why the line bellow is not working. for some reason windows does not find the file :/
-		-- rootDir .. "GenerateSolution.bat"
-		rootDir .. 'vendor/bin/premake5.exe --file="' .. rootDir .. 'premake5.lua" vs2022'
+		-- RootDir .. "GenerateSolution.bat"
+		RootDir .. '/vendor/bin/premake5.exe --file="' .. RootDir .. '/premake5.lua" vs2022'
 	}

--- a/vendor/Premake5/premake5.lua
+++ b/vendor/Premake5/premake5.lua
@@ -1,9 +1,9 @@
-include "GlobalVariable.lua"
+include "Utils.lua"
 
 project "Premake"
 	kind "Utility"
 	
-	location (projectFileLocation)
+	UseProjectDefaultConfig()
 
 	files
 	{


### PR DESCRIPTION
I created 3 helper function:
- UseDefines
- UseProjectDefaultConfig
- UseModuleDefaultConfig
Those helpers will be call in most of the project setups to set the config quickly.
Once you call one of those helpers you just have to specified what specific to this project, like the files, the include dirs, ...
I also modify the modules target output, all the dll are stored in a "Modules" directory and when building required dlls are copy next to the exe file.