### PR TITLE
Fixes #47 When a module rebuild the dll it's not moved if already exist

### DIFF
--- a/vendor/Premake5/Extended/FastUpToDateCheck.lua
+++ b/vendor/Premake5/Extended/FastUpToDateCheck.lua
@@ -1,0 +1,22 @@
+require "vstudio"
+local vc = premake.vstudio.vc2010
+
+premake.api.register {
+	name = "FastUpToDateCheck",
+	scope = "config",
+	kind = "boolean",
+	default = true
+}
+
+function FastUpToDateCheckFunction(prj, cfg)
+	if cfg.FastUpToDateCheck == false then
+		vc.element("DisableFastUpToDateCheck", nil, "true")
+	end
+end
+
+premake.override(vc.elements, "globalsCondition",
+	function(oldfn, prj, cfg)
+		local elements = oldfn(prj, cfg)
+		elements = table.join(elements, {FastUpToDateCheckFunction})
+		return elements
+	end)

--- a/vendor/Premake5/Project.lua
+++ b/vendor/Premake5/Project.lua
@@ -1,11 +1,16 @@
 ﻿include "GlobalVariable.lua"
 include "Shared.lua"
 
+include "Extended/FastUpToDateCheck.lua" -- Allow the project to disable fast up to date check
+
 ProjectTargetOutput = BuildOutput .. "/%{prj.name}"
 ProjectObjectOutput = IntermediateOutput .. "/%{prj.name}"
 
 function UseProjectDefaultConfig()
 	UseDefines()
+
+	-- Disable Fast Up To Date check, to allow the project to update the dlls after building modules
+	FastUpToDateCheck(false)
 
 	language "C++"
 	cppdialect "C++20"


### PR DESCRIPTION
Fixes #47
I fix it by disabling the fast up to date check, which will trigger the post command even if no change where made to the project