### PR TITLE
WindowsPlatformTime not working anymore

### DIFF
--- a/Source/Runtime/Core/Private/Windows/WindowsPlatformTime.cpp
+++ b/Source/Runtime/Core/Private/Windows/WindowsPlatformTime.cpp
@@ -9,7 +9,10 @@ float WindowsPlatformTime::s_TimeStep = 0.0f;
 
 float WindowsPlatformTime::GetTime()
 {
-	return (static_cast<float>(glfwGetTime()));
+	float time = static_cast<float>(glfwGetTime());
+	if (time == 0.0f)
+		glfwInit();
+	return (time);
 }
 
 float WindowsPlatformTime::GetTimeStep()

--- a/Source/Runtime/Renderer/Private/Renderer.cpp
+++ b/Source/Runtime/Renderer/Private/Renderer.cpp
@@ -1,5 +1,8 @@
 #include "Renderer.h"
 #include "Vulkan/VulkanDebugMessenger.h"
+#include "HAL/PlatformTime.h"
+
+#include <format>
 
 Renderer* Renderer::s_Instance = nullptr;
 
@@ -256,6 +259,10 @@ void Renderer::Tick()
 {
 	glfwPollEvents();
 
+	// Update title to show fps
+	const uint16_t fpsCount = (uint16_t)std::round(1.0f / PlatformTime::GetTimeStep());
+	GLFWwindow* glfwWindow = RendererModule::GetWindow();
+	glfwSetWindowTitle(glfwWindow, std::format("OpenVoxel - {:.2f}ms = {:d}fps", PlatformTime::GetTimeStep() * 100.0f, fpsCount).c_str());
 }
 
 void Renderer::InitVulkanInstance()

--- a/Source/Runtime/Renderer/Public/Renderer.h
+++ b/Source/Runtime/Renderer/Public/Renderer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Renderer_API.h"
+#include "RendererModule.h"
 #include "Vulkan/VulkanInstanceHandler.h"
 #include "Vulkan/VulkanDeviceHandler.h"
 #include "Vulkan/VulkanSwapChainHandler.h"


### PR DESCRIPTION
Fixes #55
I Update the glfw windows title to show the current FPS has a way to see that the paltform time is working at all time.
To fix the bug though, I just detect if glfwGetTime return 0 and if he does I call glfwInit.
In the future I'll probably have to change this function to not use glfwGetTime at all.