### PR TITLE
Runtime does not build anymore

### DIFF
--- a/Source/Editor/Editor/premake5.lua
+++ b/Source/Editor/Editor/premake5.lua
@@ -3,40 +3,42 @@
 project "Editor"
 	UseModuleDefaultConfig()
 
-	files
-	{
-		"**.h",
-		"**.cpp"
-	}
+	filter "configurations:Editor*"
+		files
+		{
+			"**.h",
+			"**.cpp"
+		}
 
-	includedirs
-	{
-		"Private",
-		"Public",
+		includedirs
+		{
+			"Private",
+			"Public",
 
-		-- ThirdParty
-		"../../ThirdParty/glm",
-		"../../ThirdParty/GLFW/include",
-		"%{VULKAN_SDK}/Include",
+			-- ThirdParty
+			"../../ThirdParty/glm",
+			"../../ThirdParty/GLFW/include",
+			"%{VULKAN_SDK}/Include",
 
-		-- Modules
-		"../../../Source/Runtime/Core/Public",
-		"../../../Source/Runtime/Engine/Public",
-		"../../../Source/Runtime/Renderer/Public",
-		"../../../Source/Editor/UI/Public",
-	}
+			-- Modules
+			"../../../Source/Runtime/Core/Public",
+			"../../../Source/Runtime/Engine/Public",
+			"../../../Source/Runtime/Renderer/Public",
+			"../../../Source/Editor/UI/Public",
+		}
 
-	links
-	{
-		-- ThirdParty
-		"GLFW",
-		"%{VULKAN_SDK}/Lib/vulkan-1.lib",
+		links
+		{
+			-- ThirdParty
+			"GLFW",
+			"%{VULKAN_SDK}/Lib/vulkan-1.lib",
 
-		-- Modules
-		"Core",
-		"Engine",
-		"Renderer",
-		"UI",
-	}
+			-- Modules
+			"Core",
+			"Engine",
+			"Renderer",
+			"UI",
+		}
 
-	defines "OV_BUILD_EDITOR_DLL"
+		defines "OV_BUILD_EDITOR_DLL"
+	filter {}

--- a/Source/Editor/UI/premake5.lua
+++ b/Source/Editor/UI/premake5.lua
@@ -3,38 +3,40 @@
 project "UI"
 	UseModuleDefaultConfig()
 
-	files
-	{
-		"**.h",
-		"**.cpp"
-	}
+	filter "configurations:Editor*"
+		files
+		{
+			"**.h",
+			"**.cpp"
+		}
 
-	includedirs
-	{
-		"Private",
-		"Public",
+		includedirs
+		{
+			"Private",
+			"Public",
 
-		-- ThirdParty
-		"../../ThirdParty/glm",
-		"../../ThirdParty/GLFW/include",
-		"%{VULKAN_SDK}/Include",
-		"../../ThirdParty/imgui",
+			-- ThirdParty
+			"../../ThirdParty/glm",
+			"../../ThirdParty/GLFW/include",
+			"%{VULKAN_SDK}/Include",
+			"../../ThirdParty/imgui",
 
-		-- Modules
-		"../../../Source/Runtime/Core/Public",
-		"../../../Source/Runtime/Renderer/Public",
-	}
+			-- Modules
+			"../../../Source/Runtime/Core/Public",
+			"../../../Source/Runtime/Renderer/Public",
+		}
 
-	links
-	{
-		-- ThirdParty
-		"GLFW",
-		"%{VULKAN_SDK}/Lib/vulkan-1.lib",
-		"ImGui",
-		
-		-- Modules
-		"Core",
-		"Renderer",
-	}
+		links
+		{
+			-- ThirdParty
+			"GLFW",
+			"%{VULKAN_SDK}/Lib/vulkan-1.lib",
+			"ImGui",
 
-	defines "OV_BUILD_UI_DLL"
+			-- Modules
+			"Core",
+			"Renderer",
+		}
+
+		defines "OV_BUILD_UI_DLL"
+	filter {}

--- a/premake5.lua
+++ b/premake5.lua
@@ -2,7 +2,7 @@ include "./vendor/Premake5/GlobalVariable.lua"
 include "./vendor/Premake5/Extended/workspace_files.lua" -- Allow files to be added to the workspace
 
 workspace "OpenVoxel"
-	architecture "x64"
+	architecture "x86_64"
 	configurations
 	{
 		"Runtime - Debug",


### PR DESCRIPTION
Fixes #70
So even if those modules where not used they still being compiled no matter the config. So I added a filter which pretty much tell that if no config is not editor the module is empty, no include, no link, no file, nothing. I also change x64 by x84_64 because while searching the documentation of premake x64 is an alias which is being deprecated