### PR TITLE
hcabel/make all path a path

### DIFF
--- a/Source/Runtime/Core/Private/OVModuleManager.cpp
+++ b/Source/Runtime/Core/Private/OVModuleManager.cpp
@@ -7,11 +7,11 @@ DEFINE_LOG_CATEGORY(ModuleManagerLog);
 
 void OVModuleManager::LoadModule(const char* moduleName)
 {
-	std::string modulePath = Path::GetModuleDirectoryPath() + '\\' + moduleName + ".dll";
+	Path modulePath = Path::GetModuleDirectoryPath().AppendSegment(std::string(moduleName) + ".dll");
 
 	if (PlatformFile::Exists(modulePath) == false)
 	{
-		MODULEMANAGER_LOG(Error, "Unable to load module '{:s}': module not found ('{:s}')", moduleName, modulePath);
+		MODULEMANAGER_LOG(Error, "Unable to load module '{:s}': module not found ('{:s}')", moduleName, std::string(modulePath));
 		return;
 	}
 

--- a/Source/Runtime/Core/Private/Path.cpp
+++ b/Source/Runtime/Core/Private/Path.cpp
@@ -5,6 +5,156 @@
 
 Path::DataCache Path::s_Data;
 
+Path::Path()
+{}
+
+Path::Path(const Path& ref)
+{
+	Copy(ref);
+}
+
+Path::~Path()
+{
+	m_Path.clear();
+}
+
+Path& Path::Copy(const Path& rhs)
+{
+	m_Path = rhs.m_Path;
+	return (*this);
+}
+
+Path& Path::Append(const Path& rhs)
+{
+	m_Path.insert(m_Path.end(), rhs.m_Path.begin(), rhs.m_Path.end());
+	return (*this);
+}
+
+Path& Path::Prepend(const Path& rhs)
+{
+	m_Path.insert(m_Path.begin(), rhs.m_Path.begin(), rhs.m_Path.end());
+	return (*this);
+}
+
+Path& Path::TrimSegments(size_type start, size_type end)
+{
+	if (start > end)
+		return (*this);
+	if (start >= m_Path.size())
+		return (*this);
+
+	if (end >= m_Path.size())
+		end = m_Path.size() - 1;
+
+	m_Path.erase(m_Path.begin() + start, m_Path.begin() + end + 1);
+	return (*this);
+}
+
+Path& Path::TrimTarget()
+{
+	auto targetSegment = m_Path.end() - 1;
+	if (targetSegment->find('.') != std::string::npos)
+		m_Path.erase(targetSegment);
+
+	return (*this);
+}
+
+Path& Path::InsertSegment(size_type segmentIndex, const std::string_view segment)
+{
+	if (segmentIndex > m_Path.size())
+		return (*this);
+
+	m_Path.insert(m_Path.begin() + segmentIndex, std::string(segment));
+	return (*this);
+}
+
+Path::size_type Path::FindSegment(const std::string_view segment) const
+{
+	for (size_type i = 0; i < m_Path.size(); i++)
+	{
+		if (m_Path[i] == segment)
+			return (i);
+	}
+	return (size_type());
+}
+
+Path::size_type Path::RightFindSegment(const std::string_view segment) const
+{
+	for (size_type i = m_Path.size() - 1; i >= 0; i--)
+	{
+		if (m_Path[i] == segment)
+			return (i);
+	}
+	return (-1);
+}
+
+void Path::SplitOntoSegment(const std::string_view path)
+{
+	size_t pathLength = path.size();
+
+	// calculate the number of separators in the path to allocate the right amount of memory in one go
+	size_t separatorCount = 0;
+	for (size_t i = 0; i < pathLength; i++)
+	{
+		if (IsSeparator(path[i]))
+			separatorCount++;
+	}
+	// allocate the memory
+	m_Path.reserve(separatorCount + 1);
+
+	// go through the path and split it into words
+	size_t wordStartPosition;
+	for (size_t i = 0; i < pathLength; i++)
+	{
+		wordStartPosition = i;
+		while (i < pathLength && IsSeparator(path[i]) == false)
+			i++;
+
+		m_Path.push_back(std::string(path.substr(wordStartPosition, i - wordStartPosition)));
+	}
+}
+
+std::string Path::GetPath(const char separator) const
+{
+	char buffer[MAX_PATH_LENGTH] = "";
+
+	for (size_t i = 0; i < m_Path.size(); i++)
+	{
+		strncat_s(buffer, m_Path[i].c_str(), m_Path[i].size());
+		if (i < m_Path.size() - 1)
+			strncat_s(buffer, &separator, 1);
+	}
+
+	return (std::string(buffer));
+}
+
+const std::string_view Path::GetFileTarget() const
+{
+	std::string_view lastSegment = m_Path[m_Path.size() - 1];
+	if (lastSegment.find_last_of('.') == std::string::npos)
+		return (std::string_view());
+	return (lastSegment);
+}
+
+const std::string_view Path::GetExtension() const
+{
+	std::string_view targetFile = GetFileTarget();
+	if (targetFile.empty())
+		return (std::string_view());
+
+	return (targetFile.substr(targetFile.find_last_of('.') + 1)); // +1 to skip the '.'
+}
+
+const std::string_view Path::GetFileName() const
+{
+	std::string_view targetFile = GetFileTarget();
+	if (targetFile.empty())
+		return (std::string_view());
+
+	return (targetFile.substr(0, targetFile.find_last_of('.')));
+}
+
+#pragma region Static - API
 /**
  * Create the content of a function that will get a path from the cache
  * if the cache is empty, it will call the getter function in the PlatformFileSystem to get the path.
@@ -13,32 +163,33 @@ Path::DataCache Path::s_Data;
  */
 #define PATH_GETTER_CACHED(VariableName) \
 	/* Get the VariableName from in cache */ \
-	std::string& VariableName = s_Data.VariableName; \
-	if (VariableName.empty()) \
+	Path* VariableName = s_Data.VariableName; \
+	if (VariableName == nullptr) \
 	{ \
 		/* if cache is empty, get the value using the getter function */ \
-		VariableName = PlatformFileSystem::Make##VariableName##Path(); \
+		VariableName = new Path(PlatformFileSystem::Make##VariableName##Path()); \
 	} \
-	return (VariableName); \
+	return (*VariableName);
 
-std::string Path::GetEngineRootDirectoryPath()
+Path Path::GetEngineRootDirectoryPath()
 {
 	PATH_GETTER_CACHED(EngineRootDirectory);
 }
 
-std::string Path::GetModuleDirectoryPath()
+Path Path::GetModuleDirectoryPath()
 {
 	PATH_GETTER_CACHED(ModuleDirectory);
 }
 
-std::string Path::GetLogDirectoryPath()
+Path Path::GetLogDirectoryPath()
 {
-	return (GetSavedDirectoryPath() + "logs\\");
+	return (GetSavedDirectoryPath().AppendSegment("logs"));
 }
 
-std::string Path::GetSavedDirectoryPath()
+Path Path::GetSavedDirectoryPath()
 {
-	return (GetEngineRootDirectoryPath() + "saved\\");
+	return (GetEngineRootDirectoryPath().AppendSegment("saved\\"));
 }
+#pragma endregion
 
 #undef PATH_GETTER_CACHED

--- a/Source/Runtime/Core/Private/Windows/WindowsPlatformFileSystem.cpp
+++ b/Source/Runtime/Core/Private/Windows/WindowsPlatformFileSystem.cpp
@@ -1,23 +1,25 @@
 ﻿#include "Windows/WindowsPlatformFileSystem.h"
+#include "MacrosHelper.h"
+#include "Path.h"
 
 #include <Windows.h>
 
-std::string WindowsPlatformFileSystem::MakeEngineRootDirectoryPath()
+Path WindowsPlatformFileSystem::MakeEngineRootDirectoryPath()
 {
 	// Get binary path
-	char buffer[MAX_PATH];
-	if (GetModuleFileNameA(NULL, buffer, MAX_PATH) == 0)
+	char buffer[MAX_PATH_LENGTH];
+	if (GetModuleFileNameA(NULL, buffer, MAX_PATH_LENGTH) == 0)
 		return ("");
-	std::string binaryPath = std::string(buffer);
+	Path binaryPath = buffer;
 
-	// Remove everything after "build/"
-	size_t posOfBuildFolder = binaryPath.rfind("build\\");
-	if (posOfBuildFolder != std::string::npos)
-		binaryPath = binaryPath.erase(posOfBuildFolder);
+	// Remove everything from "build" to the end
+	Path::size_type segmentIndex = binaryPath.RightFindSegment("build");
+	if (segmentIndex != -1)
+		binaryPath.TrimSegments(segmentIndex, binaryPath.GetSegmentCount() - 1);
 	return (binaryPath);
 }
 
-std::string WindowsPlatformFileSystem::MakeModuleDirectoryPath()
+Path WindowsPlatformFileSystem::MakeModuleDirectoryPath()
 {
 	HMODULE currentModuleHandle;
 	GetModuleHandleExA(
@@ -29,11 +31,11 @@ std::string WindowsPlatformFileSystem::MakeModuleDirectoryPath()
 	if (currentModuleHandle == NULL)
 		return ("");
 
-	char currentModulePath[MAX_PATH];
-	GetModuleFileNameA(currentModuleHandle, currentModulePath, MAX_PATH);
+	char currentModulePath[MAX_PATH_LENGTH];
+	GetModuleFileNameA(currentModuleHandle, currentModulePath, MAX_PATH_LENGTH);
 
-	// replace the last '\' with '\0' to crop the module name
-	*strrchr(currentModulePath, '\\') = '\0';
+	Path moduleDirectoryPath = currentModulePath;
+	moduleDirectoryPath.TrimTarget();
 
-	return (currentModulePath);
+	return (moduleDirectoryPath);
 }

--- a/Source/Runtime/Core/Public/MacrosHelper.h
+++ b/Source/Runtime/Core/Public/MacrosHelper.h
@@ -53,3 +53,11 @@
 
 #define OV_DLL_IMPORT __declspec(dllimport)
 #define OV_DLL_EXPORT __declspec(dllexport)
+
+/* Useful constant */
+
+#ifdef PLATFORM_WINDOWS
+# define MAX_PATH_LENGTH 260 // Has describe in https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation (dont want to include windows.h here too heavy)
+#else
+# define MAX_PATH_LENGTH 512 // Arbitrary value, should be enough, I have no idea what is the max path length on Linux/Mac
+#endif

--- a/Source/Runtime/Core/Public/Path.h
+++ b/Source/Runtime/Core/Public/Path.h
@@ -3,26 +3,150 @@
 #include "Core_API.h"
 
 #include <string>
+#include <vector>
 
+/**
+ * A class that represent a path.
+ * Also provide some helper function to manipulate/get paths.
+ */
 class CORE_API Path
 {
 public:
-	/** return The the root directory of the engine */
-	static std::string GetEngineRootDirectoryPath();
-	/** return the path where all the module DLL are stored */
-	static std::string GetModuleDirectoryPath();
+	// Path are limited to 65535 segments, because path are limited in characters so even in worst case scenario we will never reach this limit
+	// (could have been 255 but I want to be safe)
+	using size_type = uint16_t;
 
+public:
+	Path();
+	Path(const Path& ref);
+	Path(const char* path) { SplitOntoSegment(std::string_view(path)); }
+	Path(const std::string_view path) { SplitOntoSegment(path); }
+	~Path();
+
+#pragma region API
+public:
+	__forceinline Path& operator=(const Path& rhs) { return Copy(rhs); }
+	__forceinline operator std::string() const { return std::move(GetPath()); }
+	template<typename T>
+	__forceinline Path& operator+(const T& rhs) { return Append(rhs); }
+
+public:
+	/** Create a new path by copying the rhs path */
+	Path& Copy(const Path& rhs);
+
+	/** Add a path at the end of the first path */
+	Path& Append(const Path& rhs);
+	/** Add a path at the end of the first path */
+	template<typename T>
+	__forceinline Path& Append(const T& rhs) { return (Append(Path(rhs))); }
+
+	/** Add a path at the start of the first path */
+	Path& Prepend(const Path& rhs);
+	/** Add a path at the start of the first path */
+	template<typename T>
+	__forceinline Path& Prepend(const T& rhs) { return (Prepend(Path(rhs))); }
+
+	/** Remove segments that are between the start and end index (included) */
+	Path& TrimSegments(size_type start, size_type end);
+	/** Remove the target of the path (e.g. "A/B/Image.png" => "A/B" */
+	Path& TrimTarget();
+
+	/** Add a segment to the end of the path */
+	__forceinline Path& AppendSegment(const std::string_view segment) { return (InsertSegment(m_Path.size(), segment)); }
+	/** Add a segment to the start of the path */
+	__forceinline Path& PrependSegment(const std::string_view segment) { return (InsertSegment(0, segment)); }
+	/**
+	 * Add a segment at a given position.
+	 *
+	 * @param segmentIndex, the index where the segment will be added
+	 * @return himself
+	 */
+	Path& InsertSegment(size_type segmentIndex, const std::string_view segment);
+
+	/** Find the position of a segment that is equal to the given string */
+	size_type FindSegment(const std::string_view segment) const;
+	/** Find the position of a segment that is equal to the given string */
+	__forceinline size_type FindSegment(const char* segment) const { return (FindSegment(std::string_view(segment))); }
+	/** Find the position of a segment that is equal to the given string */
+	template<typename T>
+	__forceinline size_type FindSegment(const T& segment) const { return (FindSegment(std::string_view(segment))); }
+
+	/** Find the position of a segment that is equal to the given string, but starting from the end */
+	size_type RightFindSegment(const std::string_view segment) const;
+	/** Find the position of a segment that is equal to the given string, but starting from the end */
+	__forceinline size_type RightFindSegment(const char* segment) const { return (RightFindSegment(std::string_view(segment))); }
+	/** Find the position of a segment that is equal to the given string, but starting from the end */
+	template<typename T>
+	__forceinline size_type RightFindSegment(const T& segment) const { return (RightFindSegment(std::string_view(segment))); }
+
+public:
+	/**
+	 * Get the path has an std::string.
+	 * @note by default this function will use the operating system separator.
+	 * if you don't want this behavior use @see GetPath(char separator) const
+	 *
+	 * \return the path as an std::string
+	 */
+	__forceinline std::string GetPath() const { return GetPath(Path::PlatformSeparator); }
+	/** Get the path has an std::string using the separator passed as parameter */
+	std::string GetPath(const char separator) const;
+
+	/** Get the file targeted by the path (e.g. "Image.png") or "" if no target */
+	const std::string_view GetFileTarget() const;
+	/** Get the file extension of the targeted file (e.g. "png") or "" if no target */
+	const std::string_view GetExtension() const;
+	/** Get the name of the file target by the path (e.g. "Image") or "" if no target */
+	const std::string_view GetFileName() const;
+
+	/** Return how many segments the path has */
+	__forceinline size_type GetSegmentCount() const { return (static_cast<size_type>(m_Path.size() )); }
+	/** Return whether or not the Path is empty */
+	__forceinline bool IsEmpty() const { return (m_Path.empty()); }
+#pragma endregion
+
+private:
+	void SplitOntoSegment(const std::string_view path);
+
+private:
+	/**
+	 * The path stored as a vector of string, each string is a segment of the full path
+	 * e.g: "C:/Users/MyUser/Documents/Image.png" will be stored as ["C:", "Users", "MyUser", "Documents", "Image.png"]
+	 */
+	std::vector<std::string> m_Path;
+
+#pragma region Static - API
+public:
+	/** return the root directory of the engine */
+	static Path GetEngineRootDirectoryPath();
+	/** return the path where all the module DLL are stored */
+	static Path GetModuleDirectoryPath();
 	/** return the path where all the log files are stored */
-	static std::string GetLogDirectoryPath();
+	static Path GetLogDirectoryPath();
 	/** return the path where all the generated data file are stored */
-	static std::string GetSavedDirectoryPath();
+	static Path GetSavedDirectoryPath();
+
+	/** return whether or not the char is separator of some sort or not */
+	__forceinline static bool IsSeparator(const char c) { return (c == DefaultSeparator || c == WindowsSeprator); }
+
+public:
+	/* The default separator used by the engine to separate the path segments */
+	static constexpr char DefaultSeparator = '/';
+	/* The separator windows use to separate the path segments */
+	static constexpr char WindowsSeprator = '\\';
+#ifdef PLATFORM_WINDOWS
+	/* The separator that the platform use to separate the path segments */
+	static constexpr char PlatformSeparator = WindowsSeprator;
+#else
+	/* The separator that the platform use to separate the path segments */
+	static constexpr char PlatformSeparator = DefaultSeparator;
+#endif // PLATFORM_WINDOWS
+#pragma endregion
 
 private:
 	struct DataCache
 	{
-		std::string EngineRootDirectory;
-		std::string ModuleDirectory;
-		std::string SavedDirectory;
+		Path* EngineRootDirectory;
+		Path* ModuleDirectory;
 	};
 	static DataCache s_Data;
 };

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformDLLFile.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformDLLFile.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "Core_API.h"
+#include "Path.h"
 
 #include <windows.h>
-#include <string_view>
 
 class CORE_API WindowsPlatformDLLFile
 {
@@ -13,9 +13,9 @@ private:
 	{}
 
 public:
-	inline static WindowsPlatformDLLFile* Load(std::string_view moduleName)
+	__forceinline static WindowsPlatformDLLFile* Load(const Path& modulePath)
 	{
-		return (new WindowsPlatformDLLFile(LoadLibraryA(moduleName.data())));
+		return (new WindowsPlatformDLLFile(LoadLibraryA(modulePath.GetPath().c_str())));
 	}
 
 	inline void* GetFunctionPtr(const char* functionName) { return GetProcAddress(m_Handle, functionName); }

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformFile.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformFile.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "Core_API.h"
+#include "Path.h"
 
 #include <string_view>
 #include <iostream>
@@ -86,13 +87,12 @@ public:
 	inline static bool CreateDirectory(std::string_view path) { return (std::filesystem::create_directories(path)); }
 	inline static bool CreateDirectory(std::filesystem::path path) { return (std::filesystem::create_directories(path)); }
 	/** Check whether or not a file exist at a given path */
-	inline static bool Exists(std::string_view path) { return (std::filesystem::exists(path)); }
+	inline static bool Exists(const Path& filePath) { return (std::filesystem::exists(std::string(filePath))); }
 #pragma endregion
 
 protected:
 	std::string m_FullPath;
 	std::fstream m_FileStream;
-
 };
 
 typedef WindowsPlatformFile PlatformFile;

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformFileSystem.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformFileSystem.h
@@ -2,7 +2,7 @@
 
 #include "Core_API.h"
 
-#include <string>
+class Path;
 
 /**
  * A helper class to interact with Windows file system
@@ -11,9 +11,9 @@ class CORE_API WindowsPlatformFileSystem
 {
 public:
 	/** Find Engine root directory Path */
-	static std::string MakeEngineRootDirectoryPath();
+	static Path MakeEngineRootDirectoryPath();
 	/** Find the path where all the module are stored */
-	static std::string MakeModuleDirectoryPath();
+	static Path MakeModuleDirectoryPath();
 };
 
 typedef WindowsPlatformFileSystem PlatformFileSystem;


### PR DESCRIPTION
So I created a Path class that store a path a segment ("A/B/Image.png" will become ["A", "B", "Image.png"])
I call the last segment the target (if pointing to an actual file with extension)
I store has an array to make delimiter easy to swap, I use the GetPath() accessor has much has I can because it will the os delimiter ('\\' for windows and '/' for the other), but you can use any delimiter using the GetPath('[AnyChar]') function.
Segment management are also pretty useful when it's come to weird folder name like spaces and stuff.
So try to use the segment manipulation has much has possible.

