### PR TITLE
hcabel/Rename Platform class to not have the platform prefix

### DIFF
--- a/Source/Editor/Editor/Private/EditorEngine.cpp
+++ b/Source/Editor/Editor/Private/EditorEngine.cpp
@@ -1,7 +1,7 @@
 #include "EditorEngine.h"
 #include "OVModuleManager.h"
 #include "Renderer.h"
-#include "HAL/PlatformTime.h"
+#include "HAL/Time.h"
 #include "UI.h"
 
 EditorEngine::~EditorEngine()
@@ -23,7 +23,7 @@ void EditorEngine::EngineLoop()
 
 		UI::Get().RenderNewFrame();
 
-		PlatformTime::CalculateNewTiming();
+		Time::CalculateNewTiming();
 	}
 }
 

--- a/Source/Editor/UI/Private/UI.cpp
+++ b/Source/Editor/UI/Private/UI.cpp
@@ -99,6 +99,15 @@ void UI::PrepareNewFrame()
 
 void UI::RenderNewFrame()
 {
+
+	static bool show_demo_window = true;
+	if (show_demo_window)
+		ImGui::ShowDemoWindow(&show_demo_window);
+
+	ImGui::Begin("Another window!");
+	ImGui::Text("This is some useful text.");
+	ImGui::End();
+
 	ImGui::Render();
 
 	ImGuiIO& io = ImGui::GetIO();

--- a/Source/Runtime/Core/Private/Logging/Logger.cpp
+++ b/Source/Runtime/Core/Private/Logging/Logger.cpp
@@ -1,12 +1,12 @@
 #include "Logging/Logger.h"
-#include "HAL/PlatformTime.h"
+#include "HAL/Time.h"
 #include "Path.h"
 #include "CoreGlobals.h"
 
 #include <assert.h>
 #include <format>
 
-std::unique_ptr<PlatformFile> Logger::s_LogFile = nullptr;
+std::unique_ptr<File> Logger::s_LogFile = nullptr;
 
 void Logger::Log(Verbosity::Type verbosity, LogCategory& category, std::string message)
 {
@@ -16,7 +16,7 @@ void Logger::Log(Verbosity::Type verbosity, LogCategory& category, std::string m
 	std::string cleanMessage = message.substr(0, last);
 	// remove all newline characters
 	cleanMessage.erase(std::remove(cleanMessage.begin(), cleanMessage.end(), '\n'), cleanMessage.end());
-	
+
 	std::string logMessage = std::format("[{:s}]: {:s}: {:s}", category.GetName(), Verbosity::ToString(verbosity), cleanMessage);
 #ifdef OV_DEBUG
 	LogOntoConsole(logMessage);
@@ -38,7 +38,7 @@ void Logger::LogOntoFile(std::string_view logMessage)
 	if (s_LogFile == nullptr)
 	{
 		std::string logFilePath = GetLogFilePath();
-		s_LogFile = PlatformFile::OpenUnique(logFilePath, std::ios_base::app);
+		s_LogFile = File::OpenUnique(logFilePath, std::ios_base::app);
 	}
 	else
 		s_LogFile->Open(std::ios_base::app);
@@ -50,5 +50,5 @@ void Logger::LogOntoFile(std::string_view logMessage)
 std::string Logger::GetLogFilePath()
 {
 	// File name format: log_YYYY-MM-DD_HH-MM-SS.txt
-	return (Path::GetLogDirectoryPath() + std::format("log_{:s}.txt", PlatformTime::GetDate("%F_%H-%M-%S")));
+	return (Path::GetLogDirectoryPath() + std::format("log_{:s}.txt", Time::GetDate("%F_%H-%M-%S")));
 }

--- a/Source/Runtime/Core/Private/OVModuleManager.cpp
+++ b/Source/Runtime/Core/Private/OVModuleManager.cpp
@@ -1,6 +1,6 @@
 #include "OVModuleManager.h"
-#include "HAL/PlatformFile.h"
-#include "HAL/PlatformDLLFile.h"
+#include "HAL/File.h"
+#include "HAL/DLLFile.h"
 #include "Path.h"
 
 DEFINE_LOG_CATEGORY(ModuleManagerLog);
@@ -9,13 +9,13 @@ void OVModuleManager::LoadModule(const char* moduleName)
 {
 	Path modulePath = Path::GetModuleDirectoryPath().AppendSegment(std::string(moduleName) + ".dll");
 
-	if (PlatformFile::Exists(modulePath) == false)
+	if (File::Exists(modulePath) == false)
 	{
 		MODULEMANAGER_LOG(Error, "Unable to load module '{:s}': module not found ('{:s}')", moduleName, std::string(modulePath));
 		return;
 	}
 
-	PlatformDLLFile* moduleDLL = PlatformDLLFile::Load(modulePath);
+	DLLFile* moduleDLL = DLLFile::Load(modulePath);
 	if (!moduleDLL->IsValid())
 	{
 		MODULEMANAGER_LOG(Error, "Unable to load module '{:s}': couldn't be loaded by the OS", moduleName);

--- a/Source/Runtime/Core/Private/Path.cpp
+++ b/Source/Runtime/Core/Private/Path.cpp
@@ -1,7 +1,7 @@
 ﻿#include "Path.h"
 
 #include "Singleton.h"
-#include "HAL/PlatformFileSystem.h"
+#include "HAL/FileSystem.h"
 
 Path::DataCache Path::s_Data;
 
@@ -157,9 +157,9 @@ const std::string_view Path::GetFileName() const
 #pragma region Static - API
 /**
  * Create the content of a function that will get a path from the cache
- * if the cache is empty, it will call the getter function in the PlatformFileSystem to get the path.
+ * if the cache is empty, it will call the getter function in the FileSystem to get the path.
  * @param VariableName the name of the variable that will be used to store the path in the cache
- * @note The getter function must be named Make[VariableName]Path in the PlatformFileSystem class
+ * @note The getter function must be named Make[VariableName]Path in the FileSystem class
  */
 #define PATH_GETTER_CACHED(VariableName) \
 	/* Get the VariableName from in cache */ \
@@ -167,7 +167,7 @@ const std::string_view Path::GetFileName() const
 	if (VariableName == nullptr) \
 	{ \
 		/* if cache is empty, get the value using the getter function */ \
-		VariableName = new Path(PlatformFileSystem::Make##VariableName##Path()); \
+		VariableName = new Path(FileSystem::Make##VariableName##Path()); \
 	} \
 	return (*VariableName);
 

--- a/Source/Runtime/Core/Private/Windows/WindowsPlatformFile.cpp
+++ b/Source/Runtime/Core/Private/Windows/WindowsPlatformFile.cpp
@@ -1,6 +1,7 @@
 ﻿#include "Windows/WindowsPlatformFile.h"
 #include "Logging/LoggingMacros.h"
 #include "CoreGlobals.h"
+#include "HAL/FileSystem.h"
 
 #pragma region API
 WindowsPlatformFile::~WindowsPlatformFile()

--- a/Source/Runtime/Core/Public/HAL/DLLFile.h
+++ b/Source/Runtime/Core/Public/HAL/DLLFile.h
@@ -1,0 +1,8 @@
+
+#pragma once
+
+#include "MacrosHelper.h"
+
+#include PLATFORM_HEADER(DLLFile.h)
+
+LINK_PLATFORM_CLASS(DLLFile);

--- a/Source/Runtime/Core/Public/HAL/File.h
+++ b/Source/Runtime/Core/Public/HAL/File.h
@@ -1,0 +1,7 @@
+﻿#pragma once
+
+#include "MacrosHelper.h"
+
+#include PLATFORM_HEADER(File.h)
+
+LINK_PLATFORM_CLASS(File);

--- a/Source/Runtime/Core/Public/HAL/FileSystem.h
+++ b/Source/Runtime/Core/Public/HAL/FileSystem.h
@@ -1,0 +1,7 @@
+﻿#pragma once
+
+#include "MacrosHelper.h"
+
+#include PLATFORM_HEADER(FileSystem.h)
+
+LINK_PLATFORM_CLASS(FileSystem);

--- a/Source/Runtime/Core/Public/HAL/PlatformDLLFile.h
+++ b/Source/Runtime/Core/Public/HAL/PlatformDLLFile.h
@@ -1,6 +1,0 @@
-
-#pragma once
-
-#include "MacrosHelper.h"
-
-#include PLATFORM_HEADER(PlatformDLLFile.h)

--- a/Source/Runtime/Core/Public/HAL/PlatformFile.h
+++ b/Source/Runtime/Core/Public/HAL/PlatformFile.h
@@ -1,5 +1,0 @@
-﻿#pragma once
-
-#include "MacrosHelper.h"
-
-#include PLATFORM_HEADER(PlatformFile.h)

--- a/Source/Runtime/Core/Public/HAL/PlatformFileSystem.h
+++ b/Source/Runtime/Core/Public/HAL/PlatformFileSystem.h
@@ -1,5 +1,0 @@
-﻿#pragma once
-
-#include "MacrosHelper.h"
-
-#include PLATFORM_HEADER(PlatformFileSystem.h)

--- a/Source/Runtime/Core/Public/HAL/PlatformProcess.h
+++ b/Source/Runtime/Core/Public/HAL/PlatformProcess.h
@@ -1,6 +1,0 @@
-#pragma once
-
-#include "MacrosHelper.h"
-
-#include PLATFORM_HEADER(PlatformProcess.h)
-

--- a/Source/Runtime/Core/Public/HAL/PlatformTime.h
+++ b/Source/Runtime/Core/Public/HAL/PlatformTime.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#include "MacrosHelper.h"
-
-#include PLATFORM_HEADER(PlatformTime.h)

--- a/Source/Runtime/Core/Public/HAL/Process.h
+++ b/Source/Runtime/Core/Public/HAL/Process.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "MacrosHelper.h"
+
+#include PLATFORM_HEADER(Process.h)
+
+LINK_PLATFORM_CLASS(Process);

--- a/Source/Runtime/Core/Public/HAL/Time.h
+++ b/Source/Runtime/Core/Public/HAL/Time.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "MacrosHelper.h"
+
+#include PLATFORM_HEADER(Time.h)
+
+LINK_PLATFORM_CLASS(Time);

--- a/Source/Runtime/Core/Public/Logging/Logger.h
+++ b/Source/Runtime/Core/Public/Logging/Logger.h
@@ -2,7 +2,7 @@
 
 #include "Core_API.h"
 #include "Logging/LoggingType.h"
-#include "HAL/PlatformFile.h"
+#include "HAL/File.h"
 
 #include <iostream>
 #include <stdio.h>
@@ -26,5 +26,5 @@ private:
 	static std::string GetLogFilePath();
 
 private:
-	static std::unique_ptr<PlatformFile> s_LogFile;
+	static std::unique_ptr<File> s_LogFile;
 };

--- a/Source/Runtime/Core/Public/MacrosHelper.h
+++ b/Source/Runtime/Core/Public/MacrosHelper.h
@@ -43,11 +43,16 @@
 
 /**
  * Platform header will change the include path depending of the current platform.
- *
- * "Windows = Windows/Windows[HeaderName]"
- * "Linux = Linux/Linux[HeaderName]"
+ * return: "[PlatformName]/[PlatformName]Platform[Header]"
+ * e.g. "Windows/WindowsPlatformFile.h", "Mac/MacPlatformFile.h", "Linux/LinuxPlatformFile.h", ...
  */
-#define PLATFORM_HEADER(Header) TO_STRING(JOIN(PLATFORM_NAME/PLATFORM_NAME, Header))
+#define PLATFORM_HEADER(Header) TO_STRING(JOIN(JOIN(PLATFORM_NAME/PLATFORM_NAME, Platform), Header))
+/**
+ * Link a platform specific class to the generic class,
+ * return: typedef [PlatformName]Platform[ClassName] [ClassName];
+ * e.g. typedef WindowsPlatformFile File;
+ */
+#define LINK_PLATFORM_CLASS(ClassName) typedef JOIN(JOIN(PLATFORM_NAME, Platform), ClassName) ClassName;
 
 /* Compiler macros */
 

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformDLLFile.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformDLLFile.h
@@ -26,5 +26,3 @@ public:
 private:
 	const HMODULE m_Handle;
 };
-
-typedef WindowsPlatformDLLFile PlatformDLLFile;

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformFile.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformFile.h
@@ -22,7 +22,7 @@ private:
 	__forceinline static std::unique_ptr<WindowsPlatformFile> CreateUniqueInstance() { return std::unique_ptr<WindowsPlatformFile>(new WindowsPlatformFile()); }
 
 public:
-	/** Use PlatformFile::Copy to copy a file */
+	/** Use File::Copy to copy a file */
 	WindowsPlatformFile(const WindowsPlatformFile& other) = delete;
 	~WindowsPlatformFile();
 
@@ -94,5 +94,3 @@ protected:
 	std::string m_FullPath;
 	std::fstream m_FileStream;
 };
-
-typedef WindowsPlatformFile PlatformFile;

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformFileSystem.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformFileSystem.h
@@ -15,5 +15,3 @@ public:
 	/** Find the path where all the module are stored */
 	static Path MakeModuleDirectoryPath();
 };
-
-typedef WindowsPlatformFileSystem PlatformFileSystem;

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformProcess.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformProcess.h
@@ -7,7 +7,7 @@
 
 /**
  * class will provide information about the current process
- * 
+ *
  * /!\ WINDOWS implementation /!\
  */
 class CORE_API WindowsPlatformProcess
@@ -16,6 +16,3 @@ public:
 	/** Return the PID of the currently running process. */
 	static uint32_t Pid() { GetCurrentProcessId(); }
 };
-
-typedef WindowsPlatformProcess PlatformProcess;
-

--- a/Source/Runtime/Core/Public/Windows/WindowsPlatformTime.h
+++ b/Source/Runtime/Core/Public/Windows/WindowsPlatformTime.h
@@ -41,6 +41,3 @@ private:
 	static float s_TimeStep;
 
 };
-
-// Allow the platform to override the generic implementation.
-typedef WindowsPlatformTime PlatformTime;

--- a/Source/Runtime/Engine/Private/GameEngine.cpp
+++ b/Source/Runtime/Engine/Private/GameEngine.cpp
@@ -1,6 +1,6 @@
 #include "GameEngine.h"
 #include "Profiling/ProfilingMacros.h"
-#include "HAL/PlatformTime.h"
+#include "HAL/Time.h"
 #include "Renderer.h"
 #include "RendererModule.h"
 
@@ -21,26 +21,24 @@ void GameEngine::EngineLoop()
 {
 	OV_LOG(GameEngineLog, Display, "Engine Running");
 
-	PlatformTime::Init();
+	Time::Init();
 	while (EngineShouldStop() == false)
 	{
 		CLEAR_ALL_PERFRAME_TIMER_DATA();
 
 		Renderer::Get().PrepareNewFrame();
 
-		float timeStep = PlatformTime::GetTimeStep();
+		float timeStep = Time::GetTimeStep();
 		Tick(timeStep);
 
 		Renderer::Get().RenderNewFrame();
 
-		PlatformTime::CalculateNewTiming();
+		Time::CalculateNewTiming();
 	}
 }
 
 void GameEngine::Tick(float timeStep)
 {
-	CREATE_SCOPE_NAMED_TIMER_CONSOLE(GameEngineTick);
-
 	Renderer::Get().Tick();
 
 	// Stop();

--- a/Source/Runtime/Renderer/Private/Renderer.cpp
+++ b/Source/Runtime/Renderer/Private/Renderer.cpp
@@ -1,6 +1,6 @@
 #include "Renderer.h"
 #include "Vulkan/VulkanDebugMessenger.h"
-#include "HAL/PlatformTime.h"
+#include "HAL/Time.h"
 
 #include <format>
 
@@ -174,9 +174,9 @@ void Renderer::Tick()
 	glfwPollEvents();
 
 	// Update title to show fps
-	const uint16_t fpsCount = (uint16_t)std::round(1.0f / PlatformTime::GetTimeStep());
+	const uint16_t fpsCount = (uint16_t)std::round(1.0f / Time::GetTimeStep());
 	GLFWwindow* glfwWindow = RendererModule::GetWindow();
-	glfwSetWindowTitle(glfwWindow, std::format("OpenVoxel - {:.2f}ms = {:d}fps", PlatformTime::GetTimeStep() * 100.0f, fpsCount).c_str());
+	glfwSetWindowTitle(glfwWindow, std::format("OpenVoxel - {:.2f}ms = {:d}fps", Time::GetTimeStep() * 100.0f, fpsCount).c_str());
 }
 
 void Renderer::InitVulkanInstance()


### PR DESCRIPTION
Fixes #64
e.g. for the platform class "Time" his windows implementation is called "WindowsPlatformTime" but you used it by just calling "Time" (before it was "PlatformTime", and I feel it's no necessary)
I also create the LINK_PLATFORM_CLASS macro, so every windows implementation don't have to create the typedef themselves