### PR TITLE
hcabel/find all the module to load dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ bin-int/
 
 # Open Voxel temporary file
 Saved/
+
+# Misc
+desktop.ini

--- a/Engine/Source/Editor/Editor/Editor.build.lua
+++ b/Engine/Source/Editor/Editor/Editor.build.lua
@@ -4,12 +4,6 @@ function EditorModule(config)
 
 	Editor.Kind = "Module"
 
-	Editor.Files = {
-		"**.h",
-		"**.cpp",
-		"**.lua",
-	}
-
 	Editor.Public_IncludeDirs = {
 		"Public",
 	}

--- a/Engine/Source/Editor/UI/UI.build.lua
+++ b/Engine/Source/Editor/UI/UI.build.lua
@@ -4,12 +4,6 @@ function UIModule(config)
 
 	UI.Kind = "Module"
 
-	UI.Files = {
-		"**.h",
-		"**.cpp",
-		"**.lua",
-	}
-
 	UI.Public_IncludeDirs = {
 		"Public",
 	}

--- a/Engine/Source/Programs/BuildTools/BuildFile/Loader.lua
+++ b/Engine/Source/Programs/BuildTools/BuildFile/Loader.lua
@@ -98,8 +98,7 @@ local function ResolveBuildDataPaths(buildFileData)
 	-- list of all the build data fields that contain paths
 	local pathFields = {
 		"Public_IncludeDirs",
-		"Private_IncludeDirs",
-		"Files",
+		"Private_IncludeDirs"
 	}
 
 	-- Loop over each field that contain path for every configuration and common data

--- a/Engine/Source/Programs/BuildTools/BuildFile/Loader.lua
+++ b/Engine/Source/Programs/BuildTools/BuildFile/Loader.lua
@@ -6,7 +6,7 @@ include "../DebugUtils.lua"
 include "Utils.lua"
 
 local function BuildFileLoadingError(buildFilePath, errorMessage)
-	error("Failed to load build file: '" .. buildFilePath .. "'. " .. errorMessage)
+	error("Failed to load build file: '" .. (buildFilePath or "") .. "'. " .. (errorMessage or ""))
 end
 
 local function MoveNonConfigDataToTheRoot(buildData)
@@ -128,7 +128,7 @@ local function GetPathAndEngineScope(moduleName)
 
 		-- Is not an editor module either, we throw an error
 		if FileExists(returnBundle.Path) == false then
-			BuildFileLoadingError("Build file not found at 'Source/Runtime/[ModuleName]/[ModuleName].build.lua' or 'Source/Editor/[ModuleName]/[ModuleName].build.lua'")
+			BuildFileLoadingError("'Source/[Runtime|Editor]/" .. moduleName .. "/" .. moduleName .. ".build.lua", "Build file not found!")
 		end
 	end
 

--- a/Engine/Source/Programs/BuildTools/BuildFile/Utils.lua
+++ b/Engine/Source/Programs/BuildTools/BuildFile/Utils.lua
@@ -41,7 +41,6 @@ end
 function CreateEmptyBuildData()
 	return {
 		Kind = nil,
-		Files = {},
 		Public_IncludeDirs = {},
 		Private_IncludeDirs = {},
 		ModuleDependency = {},

--- a/Engine/Source/Programs/BuildTools/FileUtils.lua
+++ b/Engine/Source/Programs/BuildTools/FileUtils.lua
@@ -20,3 +20,21 @@ function FileExists(filePath)
 	end
 	return file ~= nil
 end
+
+function GetFolders(directory)
+	local command = 'ls -d "' .. directory .. '/*/"'
+	if package.config:sub(1,1) == '\\' then
+		command = 'dir /b /ad "' .. directory .. '"'
+	end
+
+	local folders = {}
+	local handle = io.popen(command)
+	local output = handle:read("*a")
+	handle:close()
+
+	for folder in output:gmatch("[^\r\n]+") do
+		table.insert(folders, folder)
+	end
+
+	return folders
+end

--- a/Engine/Source/Programs/BuildTools/GeneratePremakeFile.lua
+++ b/Engine/Source/Programs/BuildTools/GeneratePremakeFile.lua
@@ -15,7 +15,12 @@ function CreateApplicationProject(buildData)
 				filter ("configurations:" .. configuration)
 			end
 
-				files(data.Files)
+				-- We include all the file under the module directory
+				files({
+					buildData.RootDirectory .. "**.h",
+					buildData.RootDirectory .. "**.cpp",
+					buildData.RootDirectory .. "**.lua",
+				})
 
 				includedirs (data.Resolved.Public_IncludeDirs)
 				includedirs (data.Public_IncludeDirs)
@@ -49,7 +54,11 @@ function CreateModuleProject(buildData)
 				filter ("configurations:" .. configuration)
 			end
 
-				files(data.Files)
+				files({
+					buildData.RootDirectory .. "**.h",
+					buildData.RootDirectory .. "**.cpp",
+					buildData.RootDirectory .. "**.lua",
+				})
 
 				includedirs (data.Resolved.Public_IncludeDirs)
 				includedirs (data.Public_IncludeDirs)

--- a/Engine/Source/Runtime/Core/Core.build.lua
+++ b/Engine/Source/Runtime/Core/Core.build.lua
@@ -4,13 +4,6 @@ function CoreModule(config)
 
 	Core.Kind = "Module" -- Will be build as a dll
 
-	-- Source file of the module
-	Core.Files = {
-		"**.h",
-		"**.cpp",
-		"**.lua",
-	}
-
 	-- Include directories of the module
 	--
 	-- Module that include this module will add those Public_IncludeDirs to their include directories (automatically)

--- a/Engine/Source/Runtime/Engine/Engine.build.lua
+++ b/Engine/Source/Runtime/Engine/Engine.build.lua
@@ -4,12 +4,6 @@ function EngineModule(config)
 
 	Engine.Kind = "Module"
 
-	Engine.Files = {
-		"**.h",
-		"**.cpp",
-		"**.lua",
-	}
-
 	Engine.Public_IncludeDirs = {
 		"Public",
 	}

--- a/Engine/Source/Runtime/Launch/Launch.build.lua
+++ b/Engine/Source/Runtime/Launch/Launch.build.lua
@@ -4,12 +4,6 @@ function OpenVoxelApplication(config)
 
 	OpenVoxel.Kind = "Application"
 
-	OpenVoxel.Files = {
-		"**.h",
-		"**.cpp",
-		"**.lua",
-	}
-
 	OpenVoxel.Public_IncludeDirs = {}
 	OpenVoxel.Private_IncludeDirs = {
 		"Private",

--- a/Engine/Source/Runtime/Renderer/Renderer.build.lua
+++ b/Engine/Source/Runtime/Renderer/Renderer.build.lua
@@ -4,12 +4,6 @@ function RendererModule(config)
 
 	Renderer.Kind = "Module"
 
-	Renderer.Files = {
-		"**.h",
-		"**.cpp",
-		"**.lua",
-	}
-
 	Renderer.Public_IncludeDirs = {
 		"Public",
 	}

--- a/Engine/premake5.lua
+++ b/Engine/premake5.lua
@@ -31,20 +31,14 @@ group "Dependencies"
 	include "Source/ThirdParty/GLFW"
 group ""
 
+local RuntimeModuleName = GetFolders("Source/Runtime")
+local EditorModuleName = GetFolders("Source/Editor")
+
 group "Engine"
 	group "Engine/Editor"
-		GenerateModulesProject({
-			"Editor",
-			"UI",
-		})
+		GenerateModulesProject(EditorModuleName)
 	group "Engine"
-
-	GenerateModulesProject({
-		"Core",
-		"Renderer",
-		"Engine",
-		"Launch",
-	})
+	GenerateModulesProject(RuntimeModuleName)
 group ""
 
 group "Programs"


### PR DESCRIPTION
Now all the modules that need to be loaded a found dynamically, so if you added a module it should be automatically detected without the need or change a file.
Look at commit description to learn more.
I also remove the "Files" field in the build files (See commit)